### PR TITLE
Add Quarto template option

### DIFF
--- a/WPROJ.sty
+++ b/WPROJ.sty
@@ -1,7 +1,6 @@
 % Add all necessary packages here
 \usepackage{amsmath,amssymb,epsfig,tabularx,wrapfig}
 \usepackage{graphicx}
-\usepackage[caption=false,subrefformat=parens,labelformat=parens]{subfig}
 \usepackage{color,soul}
 \usepackage{verbatim}
 \usepackage{ifthen}

--- a/coversheet.tex
+++ b/coversheet.tex
@@ -7,10 +7,10 @@
 \vspace{2.in}
 % Enter title here
 \begin{center}
-{\LARGE\bf \maintitle} \vspace{.1in}
+{\LARGE\bfseries \maintitle} \vspace{.1in}
 
 \vspace{.05in}
-{\LARGE\bf $\;$} \\ [.5in]
+{\LARGE\bfseries $\;$} \\ [.5in]
 {\Large  \myname \\
 \vspace{0.5cm}
 Department of Mathematical Sciences \\
@@ -28,7 +28,7 @@ Master of Science in Statistics
 \null
 \vspace{2.in}
 \begin{center}
-{\bf\huge APPROVAL}\\[1.in]
+{\bfseries\huge APPROVAL}\\[1.in]
 of a writing project submitted by\\[.25in]
 \myname \\[1.in]
 \end{center}

--- a/main_LATEX.tex
+++ b/main_LATEX.tex
@@ -2,6 +2,7 @@
 
 \usepackage{WPROJ} % Style file
 \usepackage{natbib} % For bibliography citations
+\usepackage[caption=false,subrefformat=parens,labelformat=parens]{subfig}
 
 \doublespacing
 \begin{document}

--- a/main_QMD.qmd
+++ b/main_QMD.qmd
@@ -1,0 +1,59 @@
+---
+title: ''
+
+format:
+  pdf:
+    toc: true
+    number-sections: true
+    cite-method: natbib
+    include-in-header: 
+      - "WPROJ.sty"
+    include-before-body:
+      - "coversheet.tex"
+
+fontsize: 12pt
+linestretch: 2
+bibliography: references.bib
+
+editor: visual
+---
+
+```{r setup}
+#| include: false
+knitr::opts_chunk$set(echo = TRUE)
+```
+
+
+\newpage
+
+# Introduction {#sec:intro}
+
+This is my introduction, Section \ref{sec:intro}. This problem is important because... Here is the motivation for my study.
+
+In \ref{sec:background}, I will review the literature on this topic. \ref{sec:methods} describes my methods. Finally, in \ref{sec:conclusion}, I will discuss the implications of this research and future work.
+
+## Subsection
+
+This is a subsection in my Introduction section.
+
+# Literature Review {#sec:background}
+
+Review of the literature. \citet{emalgorithm} was a seminal paper describing maximum likelihood estimation for incomplete data. We wrote an R package and talk about it here \citep{TDARpackage}. Often, we cite proceedings papers \citep{plh-survey}, and sometimes we want to cite two papers at once \citep{chen2018statistical,wasserman2004}.
+
+# Methods {#sec:methods}
+
+I am describing statistical methods used in this work. Often, it is nice to have some figures throughout the document
+
+```{=tex}
+\begin{figure}[h]
+\centering
+\includegraphics[width=10cm]{figures/correlation}
+\caption{My favorite statistical cartoon \citep{xkcd}.}
+\label{cartoon}
+\end{figure}
+```
+Then, later in the text, we may reference Figure \ref{cartoon}.
+
+# Conclusion {#sec:conclusion}
+
+Amazing conclusions will be described in this section.


### PR DESCRIPTION
Posit recently announced a new project called Quarto. It's currently [very similar to R Markdown](https://quarto.org/docs/faq/rmarkdown.html) but they intend to include additional functionality and compatibility with other languages (presently Python, JS, and Julia). There are no current plans to deprecate R Markdown, but they are on record stating that they won't be backporting new features, either. It stands to reason that newer projects should use Quarto to take advantage of these new features. To that end, I've adapted the .Rmd template to a .qmd template (and made some minor, unimpactful changes to a few TeX files for compatibility's sake)